### PR TITLE
Fix example build for browser

### DIFF
--- a/examples/test-app/index.html
+++ b/examples/test-app/index.html
@@ -6,6 +6,13 @@
 </head>
 <body>
   <div id="app"></div>
-  <script src="dist/index.js"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "the-best-ui-framework": "./dist/src/index.js"
+      }
+    }
+  </script>
+  <script type="module" src="dist/index.js"></script>
 </body>
 </html>

--- a/examples/test-app/tsconfig.json
+++ b/examples/test-app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
+    "module": "es2020",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json && tsc -p examples/test-app/tsconfig.json",
+    "build": "tsc -p tsconfig.json && rm -rf examples/test-app/dist/src && cp -r dist/src examples/test-app/dist/src && tsc -p examples/test-app/tsconfig.json",
     "serve": "node serve.js",
     "test": "echo \"No tests\""
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
+    "module": "es2020",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "dist",
     "strict": true,


### PR DESCRIPTION
## Summary
- compile TypeScript modules as ES2020 and provide module resolution
- copy compiled framework into example output during build
- load framework using import map in the example HTML

## Testing
- `npm test`
- `npm run build`
